### PR TITLE
Update routes.php

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -12,7 +12,7 @@ use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 
-Router::plugin('DataTables', ['path' => '/data-tables'], function (RouteBuilder $builder) {
+RouteBuilder::plugin('DataTables', ['path' => '/data-tables'], function (RouteBuilder $builder) {
 	$builder->connect('/images/*', ['controller' => 'Assets', 'action' => 'images']);
 	$builder->fallbacks(DashedRoute::class);
 });


### PR DESCRIPTION
Router::plugin()` is deprecated, using the non-static method `RouteBuilder::plugin()